### PR TITLE
breaking changes in recipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,14 +27,14 @@ Imports:
     nortest,
     purrr,
     Rcpp,
-    recipes,
+    recipes (>= 0.1.3.9002),
     rlang,
     shiny,
     stringr,
     tibble,
     tidyr
 Suggests:
-    caret,
+    caret (>= 6.0.81),
     covr,
     descriptr,
     grid,
@@ -51,11 +51,14 @@ Suggests:
     testthat,
     tools,
     vdiffr
+Remotes:
+    topepo/caret/pkg/caret,
+    tidymodels/recipes
 License: MIT + file LICENSE
 URL: https://olsrr.rsquaredacademy.com/, https://github.com/rsquaredacademy/olsrr
 BugReports: https://github.com/rsquaredacademy/olsrr/issues
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0.9000
 LinkingTo: Rcpp

--- a/R/ols-regress_compute.R
+++ b/R/ols-regress_compute.R
@@ -52,7 +52,7 @@ reg_comp <- function(formula, data, conf.level = 0.95, iterm, title = "model") {
       step_scale(all_numeric())
 
     trained_rec <- prep(standardized, training = data)
-    newdata     <- bake(trained_rec, newdata = data_scaled)
+    newdata     <- bake(trained_rec, new_data = data_scaled)
     model2      <- lm(formula, data = newdata)
     output2     <- summary(model2)
     b           <- output2$coef[-1, 1]


### PR DESCRIPTION
We'll be releasing a new version of `recipes` in the next week and there are a few breaking changes. See the [news file](https://tidymodels.github.io/recipes/dev/news/index.html) for details. We are trying to get the breaking changes out in one release; some are for upcoming features that aren't implemented yet and we didn't want to stagger them. 

The biggest changes are the differences in argument names in the new version, the most significant is `new_data` in stead of `newdata` in `prep`. 

The plan is to send `recipes` to CRAN next week (I hope) and send `caret` in once that is accepted. I will alert CRAN that other packages are affected and the maintainers have been notified. I'll update this thread once that process starts. 
